### PR TITLE
Fixed dependency and made SC client id configurable through environment variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "jsdom": "^7.2.0",
     "mocha": "^2.3.4",
     "node-sass": "^3.4.2",
-    "react-addons-test-utils": "^0.14.7",
+    "react-addons-test-utils": "^15.0.2",
     "react-hot-loader": "^1.3.0",
     "sass-loader": "^3.1.2",
     "sinon": "^1.17.3",

--- a/src/constants/authentification.js
+++ b/src/constants/authentification.js
@@ -4,7 +4,7 @@ export const REDIRECT_URI = isDev ?
   `${window.location.protocol}//${window.location.host}/callback` :
   'http://www.favesound.de/callback';
 
-export const CLIENT_ID = isDev ?
+export const CLIENT_ID = process.env.SOUNDCLOUD_CLIENT_ID || isDev ?
     'a281614d7f34dc30b665dfcaa3ed7505' :
     '1512fb9cbe8228095fe92c6503e3a071';
 


### PR DESCRIPTION
Really small PR, but I had to change the version of `react-addons-test-utils`, otherwise `npm` would refuse to install because of invalid peerdeps.

I also thought it would it useful to be able to configure the SC client id through environment variables instead of having to change the source code.

Thanks for this great project :-)
