### PR TITLE
Migrate from React.PropTypes to prop-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "mobx-react": "4.1.8",
     "moment": "2.18.1",
     "normalizr": "2.0.0",
+    "prop-types": "15.5.10",
     "react": "15.0.2",
     "react-dom": "15.0.2",
     "react-router": "3.0.0",

--- a/src/components/Activities/index.js
+++ b/src/components/Activities/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { observer, inject } from 'mobx-react';
 import map from '../../services/map';
@@ -70,11 +71,11 @@ const Activities = observer(({
 });
 
 Activities.propTypes = {
-  requestInProcess: React.PropTypes.bool,
-  ids: React.PropTypes.object,
-  entities: React.PropTypes.object,
-  activeFilter: React.PropTypes.func,
-  activeSort: React.PropTypes.func,
+  requestInProcess: PropTypes.bool,
+  ids: PropTypes.object,
+  entities: PropTypes.object,
+  activeFilter: PropTypes.func,
+  activeSort: PropTypes.func,
 };
 
 export default FetchOnScroll(Activities);

--- a/src/components/Artwork/index.js
+++ b/src/components/Artwork/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 function Artwork({ image, title, optionalImage, size }) {
@@ -5,10 +6,10 @@ function Artwork({ image, title, optionalImage, size }) {
 }
 
 Artwork.propTypes = {
-  image: React.PropTypes.string,
-  title: React.PropTypes.string,
-  optionalImage: React.PropTypes.string,
-  size: React.PropTypes.number
+  image: PropTypes.string,
+  title: PropTypes.string,
+  optionalImage: PropTypes.string,
+  size: PropTypes.number
 };
 
 export default Artwork;

--- a/src/components/ArtworkAction/index.js
+++ b/src/components/ArtworkAction/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 
@@ -20,10 +21,10 @@ function ArtworkAction({ action, isVisible, className, children }) {
 }
 
 ArtworkAction.propTypes = {
-  action: React.PropTypes.func,
-  isVisible: React.PropTypes.bool,
-  className: React.PropTypes.string,
-  children: React.PropTypes.object,
+  action: PropTypes.func,
+  isVisible: PropTypes.bool,
+  className: PropTypes.string,
+  children: PropTypes.object,
 };
 
 export default ArtworkAction;

--- a/src/components/Browse/index.js
+++ b/src/components/Browse/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { observer, inject } from 'mobx-react';
 import { DEFAULT_GENRE } from '../../constants/genre';
@@ -60,12 +61,12 @@ class Browse extends React.Component {
 }
 
 Browse.wrappedComponent.propTypes = {
-  browseStore: React.PropTypes.object.isRequired,
-  entityStore: React.PropTypes.object.isRequired,
-  paginateStore: React.PropTypes.object.isRequired,
-  requestStore: React.PropTypes.object.isRequired,
-  filterStore: React.PropTypes.object.isRequired,
-  sortStore: React.PropTypes.object.isRequired,
+  browseStore: PropTypes.object.isRequired,
+  entityStore: PropTypes.object.isRequired,
+  paginateStore: PropTypes.object.isRequired,
+  requestStore: PropTypes.object.isRequired,
+  filterStore: PropTypes.object.isRequired,
+  sortStore: PropTypes.object.isRequired,
 };
 
 export default Browse;

--- a/src/components/ButtonActive/index.js
+++ b/src/components/ButtonActive/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 import ButtonInline from '../../components/ButtonInline';
@@ -20,8 +21,8 @@ function ButtonActive({ onClick, isActive, children }) {
 }
 
 ButtonActive.propTypes = {
-  isActive: React.PropTypes.bool,
-  onClick: React.PropTypes.func,
+  isActive: PropTypes.bool,
+  onClick: PropTypes.func,
 };
 
 export default ButtonActive;

--- a/src/components/ButtonGhost/index.js
+++ b/src/components/ButtonGhost/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 
@@ -17,8 +18,8 @@ function ButtonGhost({ onClick, isSmall, children }) {
 }
 
 ButtonGhost.propTypes = {
-  isSmall: React.PropTypes.bool,
-  onClick: React.PropTypes.func,
+  isSmall: PropTypes.bool,
+  onClick: PropTypes.func,
 };
 
 export default ButtonGhost;

--- a/src/components/ButtonInline/index.js
+++ b/src/components/ButtonInline/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 function ButtonInline({ onClick, children }) {
@@ -9,7 +10,7 @@ function ButtonInline({ onClick, children }) {
 }
 
 ButtonInline.propTypes = {
-  onClick: React.PropTypes.func,
+  onClick: PropTypes.func,
 };
 
 export default ButtonInline;

--- a/src/components/ButtonMore/index.js
+++ b/src/components/ButtonMore/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import LoadingSpinner from '../../components/LoadingSpinner';
 import ButtonGhost from '../../components/ButtonGhost';
@@ -16,10 +17,10 @@ function ButtonMore({ onClick, requestInProcess, nextHref, isHidden }) {
 }
 
 ButtonMore.propTypes = {
-  nextHref: React.PropTypes.string,
-  requestInProcess: React.PropTypes.bool,
-  isHidden: React.PropTypes.bool,
-  onClick: React.PropTypes.func,
+  nextHref: PropTypes.string,
+  requestInProcess: PropTypes.bool,
+  isHidden: PropTypes.bool,
+  onClick: PropTypes.func,
 };
 
 export default ButtonMore;

--- a/src/components/CommentExtension/index.js
+++ b/src/components/CommentExtension/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { observer, inject } from 'mobx-react';
 import map from '../../services/map';
@@ -73,11 +74,11 @@ const CommentExtensionContainer = inject(
 }));
 
 CommentExtensionContainer.wrappedComponent.propTypes = {
-  activity: React.PropTypes.object.isRequired,
-  commentStore: React.PropTypes.object.isRequired,
-  entityStore: React.PropTypes.object.isRequired,
-  requestStore: React.PropTypes.object.isRequired,
-  paginateStore: React.PropTypes.object.isRequired,
+  activity: PropTypes.object.isRequired,
+  commentStore: PropTypes.object.isRequired,
+  entityStore: PropTypes.object.isRequired,
+  requestStore: PropTypes.object.isRequired,
+  paginateStore: PropTypes.object.isRequired,
 };
 
 export default CommentExtensionContainer;

--- a/src/components/FavoritesList/index.js
+++ b/src/components/FavoritesList/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { observer, inject } from 'mobx-react';
 import * as actions from '../../actions/index';
@@ -62,12 +63,12 @@ const FavoritesListContainer = inject(
 }));
 
 FavoritesListContainer.wrappedComponent.propTypes = {
-  sessionStore: React.PropTypes.object.isRequired,
-  userStore: React.PropTypes.object.isRequired,
-  entityStore: React.PropTypes.object.isRequired,
-  paginateStore: React.PropTypes.object.isRequired,
-  requestStore: React.PropTypes.object.isRequired,
-  toggleStore: React.PropTypes.object.isRequired
+  sessionStore: PropTypes.object.isRequired,
+  userStore: PropTypes.object.isRequired,
+  entityStore: PropTypes.object.isRequired,
+  paginateStore: PropTypes.object.isRequired,
+  requestStore: PropTypes.object.isRequired,
+  toggleStore: PropTypes.object.isRequired
 };
 
 export default FavoritesListContainer;

--- a/src/components/FetchOnScroll/index.js
+++ b/src/components/FetchOnScroll/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 export default function(InnerComponent) {
@@ -27,7 +28,7 @@ export default function(InnerComponent) {
   }
 
   FetchOnScrollComponent.propTypes = {
-    scrollFunction: React.PropTypes.func.isRequired,
+    scrollFunction: PropTypes.func.isRequired,
   };
 
   return FetchOnScrollComponent;

--- a/src/components/FilterDuration/index.js
+++ b/src/components/FilterDuration/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { observer, inject } from 'mobx-react';
 import map from '../../services/map';
@@ -61,7 +62,7 @@ const FilterDurationContainer = inject(
 }));
 
 FilterDurationContainer.wrappedComponent.propTypes = {
-  filterStore: React.PropTypes.object.isRequired
+  filterStore: PropTypes.object.isRequired
 };
 
 export default FilterDurationContainer;

--- a/src/components/FilterName/index.js
+++ b/src/components/FilterName/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { observer, inject } from 'mobx-react';
 import classNames from 'classnames';
@@ -47,7 +48,7 @@ const FilterNameContainer = inject(
 }));
 
 FilterNameContainer.wrappedComponent.propTypes = {
-  filterStore: React.PropTypes.object.isRequired
+  filterStore: PropTypes.object.isRequired
 };
 
 export default FilterNameContainer;

--- a/src/components/FollowersList/index.js
+++ b/src/components/FollowersList/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { observer, inject } from 'mobx-react';
 import * as actions from '../../actions/index';
@@ -62,12 +63,12 @@ const FollowersListContainer = inject(
 }));
 
 FollowersListContainer.wrappedComponent.propTypes = {
-  sessionStore: React.PropTypes.object.isRequired,
-  userStore: React.PropTypes.object.isRequired,
-  entityStore: React.PropTypes.object.isRequired,
-  paginateStore: React.PropTypes.object.isRequired,
-  requestStore: React.PropTypes.object.isRequired,
-  toggleStore: React.PropTypes.object.isRequired
+  sessionStore: PropTypes.object.isRequired,
+  userStore: PropTypes.object.isRequired,
+  entityStore: PropTypes.object.isRequired,
+  paginateStore: PropTypes.object.isRequired,
+  requestStore: PropTypes.object.isRequired,
+  toggleStore: PropTypes.object.isRequired
 };
 
 export default FollowersListContainer;

--- a/src/components/FollowingsList/index.js
+++ b/src/components/FollowingsList/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { observer, inject } from 'mobx-react';
 import * as actions from '../../actions/index';
@@ -62,12 +63,12 @@ const FollowingsListContainer = inject(
 }));
 
 FollowingsListContainer.wrappedComponent.propTypes = {
-  sessionStore: React.PropTypes.object.isRequired,
-  userStore: React.PropTypes.object.isRequired,
-  entityStore: React.PropTypes.object.isRequired,
-  paginateStore: React.PropTypes.object.isRequired,
-  requestStore: React.PropTypes.object.isRequired,
-  toggleStore: React.PropTypes.object.isRequired
+  sessionStore: PropTypes.object.isRequired,
+  userStore: PropTypes.object.isRequired,
+  entityStore: PropTypes.object.isRequired,
+  paginateStore: PropTypes.object.isRequired,
+  requestStore: PropTypes.object.isRequired,
+  toggleStore: PropTypes.object.isRequired
 };
 
 export default FollowingsListContainer;

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { observer, inject } from 'mobx-react';
 import map from '../../services/map';
@@ -92,9 +93,9 @@ const Header = inject(
 }));
 
 Header.wrappedComponent.propTypes = {
-  sessionStore: React.PropTypes.object,
-  genre: React.PropTypes.string,
-  pathname: React.PropTypes.string,
+  sessionStore: PropTypes.object,
+  genre: PropTypes.string,
+  pathname: PropTypes.string,
 };
 
 Header.wrappedComponent.defaultProps = {

--- a/src/components/HoverActions/index.js
+++ b/src/components/HoverActions/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import map from '../../services/map';
 import classNames from 'classnames';
@@ -31,8 +32,8 @@ function Actions({ configuration, isVisible }) {
 }
 
 Actions.propTypes = {
-  configuration: React.PropTypes.array,
-  isVisible: React.PropTypes.bool
+  configuration: PropTypes.array,
+  isVisible: PropTypes.bool
 };
 
 export default Actions;

--- a/src/components/InfoList/index.js
+++ b/src/components/InfoList/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 import map from '../../services/map';
@@ -28,7 +29,7 @@ function InfoList({ information }) {
 }
 
 InfoList.propTypes = {
-  information: React.PropTypes.array
+  information: PropTypes.array
 };
 
 export default InfoList;

--- a/src/components/List/index.js
+++ b/src/components/List/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import map from '../../services/map';
 import { observer, inject } from 'mobx-react';
@@ -124,15 +125,15 @@ function List({
 }
 
 List.propTypes = {
-  ids: React.PropTypes.object,
-  isExpanded: React.PropTypes.bool,
-  title: React.PropTypes.string,
-  kind: React.PropTypes.string,
-  requestInProcess: React.PropTypes.bool,
-  entities: React.PropTypes.object,
-  nextHref: React.PropTypes.string,
-  onToggleMore: React.PropTypes.func,
-  onFetchMore: React.PropTypes.func
+  ids: PropTypes.object,
+  isExpanded: PropTypes.bool,
+  title: PropTypes.string,
+  kind: PropTypes.string,
+  requestInProcess: PropTypes.bool,
+  entities: PropTypes.object,
+  nextHref: PropTypes.string,
+  onToggleMore: PropTypes.func,
+  onFetchMore: PropTypes.func
 };
 
 export default List;

--- a/src/components/LoadingSpinner/index.js
+++ b/src/components/LoadingSpinner/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 function LoadingSpinner({ isLoading }) {
@@ -11,7 +12,7 @@ function LoadingSpinner({ isLoading }) {
 }
 
 LoadingSpinner.propTypes = {
-  isLoading: React.PropTypes.bool
+  isLoading: PropTypes.bool
 };
 
 export default LoadingSpinner;

--- a/src/components/Permalink/index.js
+++ b/src/components/Permalink/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 function Permalink({ link, text }) {
@@ -9,8 +10,8 @@ function Permalink({ link, text }) {
 }
 
 Permalink.propTypes = {
-  link: React.PropTypes.string,
-  text: React.PropTypes.string
+  link: PropTypes.string,
+  text: PropTypes.string
 };
 
 export default Permalink;

--- a/src/components/Player/index.js
+++ b/src/components/Player/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { observer, inject } from 'mobx-react';
@@ -99,10 +100,10 @@ class Player extends React.Component {
 }
 
 Player.wrappedComponent.propTypes = {
-  sessionStore: React.PropTypes.object,
-  entityStore: React.PropTypes.object,
-  playerStore: React.PropTypes.object,
-  toggleStore: React.PropTypes.object,
+  sessionStore: PropTypes.object,
+  entityStore: PropTypes.object,
+  playerStore: PropTypes.object,
+  toggleStore: PropTypes.object,
 };
 
 export default Player;

--- a/src/components/Playlist/index.js
+++ b/src/components/Playlist/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { observer, inject } from 'mobx-react';
 import map from '../../services/map';
@@ -87,9 +88,9 @@ const PlaylistContainer = inject(
 }));
 
 PlaylistContainer.wrappedComponent.propTypes = {
-  entityStore: React.PropTypes.object,
-  playerStore: React.PropTypes.object,
-  toggleStore: React.PropTypes.object,
+  entityStore: PropTypes.object,
+  playerStore: PropTypes.object,
+  toggleStore: PropTypes.object,
 };
 
 export default PlaylistContainer;

--- a/src/components/Sort/index.js
+++ b/src/components/Sort/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import map from '../../services/map';
 import classNames from 'classnames';
@@ -53,7 +54,7 @@ const SortContainer = inject(
 }));
 
 SortContainer.wrappedComponent.propTypes = {
-  sortStore: React.PropTypes.object.isRequired
+  sortStore: PropTypes.object.isRequired
 };
 
 export default SortContainer;

--- a/src/components/StreamActivities/index.js
+++ b/src/components/StreamActivities/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { observer, inject } from 'mobx-react';
 import * as actions from '../../actions/index';
@@ -39,13 +40,13 @@ const StreamActivities = inject(
 }));
 
 StreamActivities.wrappedComponent.propTypes = {
-  userStore: React.PropTypes.object,
-  entityStore: React.PropTypes.object,
-  playerStore: React.PropTypes.object,
-  paginateStore: React.PropTypes.object,
-  requestStore: React.PropTypes.object,
-  sortStore: React.PropTypes.object,
-  filterStore: React.PropTypes.object
+  userStore: PropTypes.object,
+  entityStore: PropTypes.object,
+  playerStore: PropTypes.object,
+  paginateStore: PropTypes.object,
+  requestStore: PropTypes.object,
+  sortStore: PropTypes.object,
+  filterStore: PropTypes.object
 };
 
 export default StreamActivities;

--- a/src/components/Track/playlist.js
+++ b/src/components/Track/playlist.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Artwork from '../../components/Artwork';
 import Permalink from '../../components/Permalink';
@@ -45,12 +46,12 @@ function TrackPlaylist({
 }
 
 TrackPlaylist.propTypes = {
-  activity: React.PropTypes.object,
-  userEntities: React.PropTypes.object,
-  isPlaying: React.PropTypes.bool,
-  activeTrackId: React.PropTypes.number,
-  onActivateTrack: React.PropTypes.func,
-  onRemoveTrackFromPlaylist: React.PropTypes.func
+  activity: PropTypes.object,
+  userEntities: PropTypes.object,
+  isPlaying: PropTypes.bool,
+  activeTrackId: PropTypes.number,
+  onActivateTrack: PropTypes.func,
+  onRemoveTrackFromPlaylist: PropTypes.func
 };
 
 export default TrackPlaylist;

--- a/src/components/Track/preview.js
+++ b/src/components/Track/preview.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Artwork from '../../components/Artwork';
 import Permalink from '../../components/Permalink';
@@ -60,12 +61,12 @@ function TrackPreview({
 }
 
 TrackPreview.propTypes = {
-  userEntities: React.PropTypes.object,
-  activity: React.PropTypes.object,
-  isPlaying: React.PropTypes.bool,
-  activeTrackId: React.PropTypes.number,
-  onActivateTrack: React.PropTypes.func,
-  onAddTrackToPlaylist: React.PropTypes.func
+  userEntities: PropTypes.object,
+  activity: PropTypes.object,
+  isPlaying: PropTypes.bool,
+  activeTrackId: PropTypes.number,
+  onActivateTrack: PropTypes.func,
+  onAddTrackToPlaylist: PropTypes.func
 };
 
 export default TrackPreview;

--- a/src/components/Track/stream.js
+++ b/src/components/Track/stream.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { observer } from 'mobx-react';
 import classNames from 'classnames';
@@ -148,16 +149,16 @@ function RepostIcon({ repostCount }) {
 }
 
 TrackStream.propTypes = {
-  userEntities: React.PropTypes.object,
-  typeReposts: React.PropTypes.object,
-  typeTracks: React.PropTypes.object,
-  activity: React.PropTypes.object,
-  isPlaying: React.PropTypes.bool,
-  activeTrackId: React.PropTypes.number,
-  idx: React.PropTypes.number,
-  activeSortType: React.PropTypes.string,
-  activeDurationFilterType: React.PropTypes.string,
-  onActivateTrack: React.PropTypes.func,
+  userEntities: PropTypes.object,
+  typeReposts: PropTypes.object,
+  typeTracks: PropTypes.object,
+  activity: PropTypes.object,
+  isPlaying: PropTypes.bool,
+  activeTrackId: PropTypes.number,
+  idx: PropTypes.number,
+  activeSortType: PropTypes.string,
+  activeDurationFilterType: PropTypes.string,
+  onActivateTrack: PropTypes.func,
 };
 
 export default TrackStream;

--- a/src/components/TrackActions/index.js
+++ b/src/components/TrackActions/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import * as actions from '../../actions/index';
 import ButtonGhost from '../../components/ButtonGhost';
@@ -21,8 +22,8 @@ function TrackActions({ onOpenComments, onAddTrackToPlaylist }) {
 }
 
 TrackActions.propTypes = {
-  onOpenComments: React.PropTypes.func,
-  onAddTrackToPlaylist: React.PropTypes.func,
+  onOpenComments: PropTypes.func,
+  onAddTrackToPlaylist: PropTypes.func,
 };
 
 function TrackActionsContainer({ activity }) {

--- a/src/components/TrackExtension/index.js
+++ b/src/components/TrackExtension/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { observer } from 'mobx-react';
 import * as actions from '../../actions/index';
@@ -13,8 +14,8 @@ function TrackExtension({ activity, isOpenComment }) {
 }
 
 TrackExtension.propTypes = {
-  activity: React.PropTypes.object,
-  openComments: React.PropTypes.func,
+  activity: PropTypes.object,
+  openComments: PropTypes.func,
 };
 
 const TrackExtensionContainer = observer(({ activity }) => {
@@ -28,7 +29,7 @@ const TrackExtensionContainer = observer(({ activity }) => {
 });
 
 TrackExtensionContainer.propTypes = {
-  activity: React.PropTypes.object,
+  activity: PropTypes.object,
 };
 
 export default TrackExtensionContainer;

--- a/src/components/User/index.js
+++ b/src/components/User/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { observer, inject } from 'mobx-react';
 import * as actions from '../../actions/index';
@@ -19,8 +20,8 @@ const UserPreviewContainer = inject(
 }));
 
 UserPreviewContainer.wrappedComponent.propTypes = {
-  user: React.PropTypes.object,
-  userStore: React.PropTypes.object,
+  user: PropTypes.object,
+  userStore: PropTypes.object,
 };
 
 export default UserPreviewContainer;

--- a/src/components/User/preview.js
+++ b/src/components/User/preview.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { observer } from 'mobx-react';
 import find from 'lodash/fp/find';
@@ -50,9 +51,9 @@ const UserPreview = observer(({
 });
 
 UserPreview.propTypes = {
-  followings: React.PropTypes.object,
-  user: React.PropTypes.object,
-  onFollow: React.PropTypes.func
+  followings: PropTypes.object,
+  user: PropTypes.object,
+  onFollow: PropTypes.func
 };
 
 export default UserPreview;

--- a/src/components/WaveformSc/index.js
+++ b/src/components/WaveformSc/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Waveform from 'waveform.js';
 import { normalizeSamples, isJsonWaveform, isPngWaveform } from '../../services/track';
@@ -60,8 +61,8 @@ class WaveformSc extends React.Component {
 }
 
 WaveformSc.propTypes = {
-  activity: React.PropTypes.object,
-  idx: React.PropTypes.number
+  activity: PropTypes.object,
+  idx: PropTypes.number
 };
 
 export {


### PR DESCRIPTION
Pull request for #6: Migrate React.PropTypes to use prop-types package for React 15.4