### PR TITLE
Upgraded react router to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,9 +68,11 @@
     "moment": "2.18.1",
     "normalizr": "2.0.0",
     "prop-types": "15.5.10",
+    "query-string": "4.3.4",
     "react": "15.6.1",
     "react-dom": "15.6.1",
-    "react-router": "3.0.0",
+    "react-router": "4.1.1",
+    "react-router-dom": "4.1.1",
     "soundcloud": "3.0.1",
     "waveform.js": "1.0.0",
     "whatwg-fetch": "2.0.3"

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -1,20 +1,25 @@
 import React from 'react';
-import { DEFAULT_GENRE } from '../../constants/genre';
+import { Route, Switch, Redirect } from 'react-router-dom';
+import Browse from '../../components/Browse';
+import Callback from '../../components/Callback';
+import Dashboard from '../../components/Dashboard';
 import Header from '../../components/Header';
 import Player from '../../components/Player';
 import Playlist from '../../components/Playlist';
+import { browse, dashboard, callback } from '../../constants/pathnames';
 
 export default class App extends React.Component {
 
   render() {
-    const { location, children } = this.props;
-    const { pathname, query } = location;
-    const genre = query.genre || DEFAULT_GENRE;
-
     return (
       <div>
-        <Header genre={genre} pathname={pathname} />
-          {children}
+        <Header />
+        <Switch>
+          <Route exact path={browse} component={Browse} />
+          <Route exact path={dashboard} component={Dashboard} />
+          <Route exact path={callback} component={Callback} />
+          <Redirect to={browse} />
+        </Switch>
         <Playlist />
         <Player />
       </div>

--- a/src/components/Browse/index.js
+++ b/src/components/Browse/index.js
@@ -6,6 +6,7 @@ import * as actions from '../../actions/index';
 import * as requestTypes from '../../constants/requestTypes';
 import Activities from '../../components/Activities';
 import StreamInteractions from '../../components/StreamInteractions';
+import { parse } from 'query-string';
 
 @inject('browseStore', 'entityStore', 'paginateStore', 'requestStore', 'filterStore', 'sortStore') @observer
 class Browse extends React.Component {
@@ -25,24 +26,27 @@ class Browse extends React.Component {
     this.fetchActivitiesByGenre();
   }
 
+  parseGenreFromLocation(location) {
+    return parse(location.search).genre || DEFAULT_GENRE;
+  }
+
   fetchActivitiesByGenre() {
     const { location, paginateStore } = this.props;
-    const genre = location.query.genre || DEFAULT_GENRE;
+    const genre = this.parseGenreFromLocation(location);
     const nextHref = paginateStore.getLinkByType(genre);
     actions.fetchActivitiesByGenre(nextHref, genre);
   }
 
   needToFetchActivities() {
     const { location, browseStore } = this.props;
-    const genre = location.query.genre || DEFAULT_GENRE;
+    const genre = this.parseGenreFromLocation(location);
     const activitiesByGenre = browseStore.getByGenre(genre);
     return (activitiesByGenre ? activitiesByGenre.toJS() : []).length < 20;
   }
 
   render() {
     const { browseStore, entityStore, requestStore, filterStore, location, sortStore } = this.props;
-    const genre = location.query.genre || DEFAULT_GENRE;
-
+    const genre = this.parseGenreFromLocation(location);
     return (
       <div className="browse">
         <StreamInteractions />

--- a/src/index.js
+++ b/src/index.js
@@ -4,27 +4,17 @@ import SC from 'soundcloud';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'mobx-react';
-import { Router, Route, IndexRoute, browserHistory } from 'react-router';
-import Dashboard from './components/Dashboard';
-import Browse from './components/Browse';
-import Callback from './components/Callback';
+import { BrowserRouter } from 'react-router-dom';
 import App from './components/App';
-import { browse, dashboard, callback } from './constants/pathnames';
 import * as stores from './stores';
 
 require('../styles/index.scss');
 
 ReactDOM.render(
   <Provider { ...stores }>
-    <Router history={browserHistory}>
-      <Route path="/" component={App}>
-        <IndexRoute component={Browse} />
-        <Route path={callback} component={Callback} />
-        <Route path={dashboard} component={Dashboard} />
-        <Route path={browse} component={Browse} />
-        <Route path="*" component={Browse} />
-      </Route>
-    </Router>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </Provider>,
   document.getElementById('app')
 );


### PR DESCRIPTION
For issue: #5 
@rwieruch 
I have upgraded the react-router to version 4, however it is not done in the same way of its sibling project(favesound-redux). I preserved the original way of specifying the genre: http://localhost:8080/browse?genre=Minimal instead of http://localhost:8080/browse/Minimal (In favesound-redux).

Let me know which way you prefer, thanks.